### PR TITLE
nix: add gitignore changes, and change flake packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/result

--- a/default.nix
+++ b/default.nix
@@ -6,8 +6,8 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "areif-dev";
     repo = "river-bsp-layout";
-    rev = "dfe84fc12fd6d0e6afb3d28bd94cc26805d3923d";
-    hash = "sha256-WgjC+BcyMaToOw+endHccjCHrCyi4NGN+611AI3FhC8=";
+    rev = "f27d1d0d492c7e0022695e2a7a0fdf9343877d3d";
+    sha256 = "xsH5dyBx7UiIuttBkixjP+SXelyUI9feVncp574G8KU=";
   };
   cargoLock.lockFile = ./Cargo.lock;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715266358,
-        "narHash": "sha256-doPgfj+7FFe9rfzWo1siAV2mVCasW+Bh8I1cToAXEE4=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1715393623,
-        "narHash": "sha256-nSUFcUqyTQQ/aYFIB05mpCzytcKvfKMy3ZQAe0fP26A=",
+        "lastModified": 1716862669,
+        "narHash": "sha256-7oTPM9lcdwiI1cpRC313B+lHawocgpY5F07N+Rbm5Uk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8eb8671512cb0c72c748058506e50c54fb5d8e2b",
+        "rev": "47b2d15658b37716393b2463a019000dbd6ce4bc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,22 +18,24 @@
           };
         };
       };
-      
+
       perSystem = { config, system, pkgs, ... }: {
         _module.args.pkgs = import nixpkgs {
           inherit system;
           overlays = [ (import inputs.rust-overlay) self.overlays.default ];
         };
-        
+
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [ rust-bin.stable.latest.default ];
         };
-        
+
         packages.river-bsp-layout = pkgs.river-bsp-layout;
         packages.default = config.packages.river-bsp-layout;
 
         apps.river-bsp-layout.program = "${config.packages.river-bsp-layout}/bin/river-bsp-layout";
         apps.default.program = config.apps.river-bsp-layout.program;
+
+        formatter = pkgs.nixpkgs-fmt;
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,16 +18,22 @@
           };
         };
       };
+      
       perSystem = { config, system, pkgs, ... }: {
         _module.args.pkgs = import nixpkgs {
           inherit system;
           overlays = [ (import inputs.rust-overlay) self.overlays.default ];
         };
+        
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [ rust-bin.stable.latest.default ];
         };
-        packages.default = pkgs.river-bsp-layout;
+        
+        packages.river-bsp-layout = pkgs.river-bsp-layout;
+        packages.default = config.packages.river-bsp-layout;
 
+        apps.river-bsp-layout.program = "${config.packages.river-bsp-layout}/bin/river-bsp-layout";
+        apps.default.program = config.apps.river-bsp-layout.program;
       };
     };
 }


### PR DESCRIPTION
### What happened?
The flake was producing an error during build. This was because the SHA256 of the commit and the commit itself didn't line up.
I have tested compiling this and it *has* built.

### What have I also made changes to?
I have added the `result/` directory produced by Nix when running this command to the `.gitignore`:
```shell
% nix build .#
```

I have also, for convenience, renamed `packages.default` to `packages.river-bsp-layout`, There is still a `packages.default`, but I made it feed off of `packages.river-bsp-layout` however.