### PR TITLE
Fix nix package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,9 @@
-{ rustPlatform, version ? "git" }:
+{ rustPlatform, version ? "git", lib }:
 rustPlatform.buildRustPackage {
   pname = "river-bsp-layout";
   inherit version;
 
-  src = ./.;
+  src = lib.cleanSource ./.;
+
   cargoLock.lockFile = ./Cargo.lock;
 }

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,8 @@
-{ fetchFromGitHub, rustPlatform, lib }:
-rustPlatform.buildRustPackage rec {
+{ fetchFromGitHub, rustPlatform, lib, version ? "git" }:
+rustPlatform.buildRustPackage {
   pname = "river-bsp-layout";
-  version = "2.1.0";
+  inherit version;
 
-  src = fetchFromGitHub {
-    owner = "areif-dev";
-    repo = "river-bsp-layout";
-    rev = "v${version}";
-    sha256 = "sha256-LRVZPAS4V5PtrqyOkKUfrZuwLqPZbLoyjn2DPxCFE2o=";
-  };
-
+  src = ./.;
   cargoLock.lockFile = ./Cargo.lock;
 }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, rustPlatform, lib, version ? "git" }:
+{ rustPlatform, version ? "git" }:
 rustPlatform.buildRustPackage {
   pname = "river-bsp-layout";
   inherit version;

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723637854,
-        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "lastModified": 1726062873,
+        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
         "type": "github"
       },
       "original": {
@@ -36,14 +36,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "nixpkgs_2": {
@@ -74,11 +74,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1723688259,
-        "narHash": "sha256-WzeUR1MG9MnJnh9T7qcVe/v12qHvJvzdc3Z5HCeE2ns=",
+        "lastModified": 1726382494,
+        "narHash": "sha256-T7W+ohiXe1IY0yf/PpS4wQItZ0SyRO+/v8kqNpMXlI4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6e75319846684326d900daff1e2e11338cc80d2b",
+        "rev": "ff13821613ffe5dbfeb4fe353b1f4bf291d831db",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       flake = {
         overlays.default = final: prev: {
           river-bsp-layout = final.callPackage ./default.nix {
-            inherit (prev) fetchFromGitHub rustPlatform;
+            inherit (prev) rustPlatform;
           };
         };
       };


### PR DESCRIPTION
Old package had multiple issues:
1) The old package required updating hashes so as to build its own repo over network.
2) The old package was missing `cargoHash` (this prevented it from building, as cargo over network must be a FOD).
3) The old package required updating version on release, and didn't support latest commit.